### PR TITLE
Fixes to CLI help and docopt config

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ You'll find the sources of the project on https://github.com/guyzmo/pyparts
       lookup         Search part
       specs          Get specs for a part
       datasheet      Download part's datasheet
-      open           Open part's page in browser
+      show           Open part's page in browser
       help           Give help for a command
 
     See `pyparts.py help <command>` to get more information on a command

--- a/pyparts/parts.py
+++ b/pyparts/parts.py
@@ -163,7 +163,7 @@ class PyPartsOctopart(PyPartsBase):
     '''
     def __init__(self, apikey, verbose=False):
         '''
-        instanciate an engine
+        instantiate an engine
         '''
         self._e = Octopart(apikey=apikey, verbose=verbose)
 

--- a/pyparts/parts.py
+++ b/pyparts/parts.py
@@ -32,7 +32,7 @@ Commands:
   lookup         Search part
   specs          Get specs for a part
   datasheet      Download part's datasheet
-  open           Open part's page in browser
+  show           Open part's page in browser
   help           Give help for a command
 
 See `pyparts help <command>` to get more information on a command
@@ -429,7 +429,7 @@ class CLI:
                 'Search for a part\'s product name.\n' \
                 '\n\n'
     search = lookup.replace('lookup', 'search')
-    specs =     ' Usage: pyparts specs [options] <part>\n' \
+    specs =     'Usage: pyparts specs [options] <part>\n' \
                 '\n' \
                 'Outputs the part\'s specifications.\n' \
                 '\n'
@@ -438,8 +438,8 @@ class CLI:
                 'Download and show the datasheet(s) of a given part\n' \
                 '\n' \
                 'Actions:\n' \
-                '    open    Open datasheet' \
-                '    save    Save datasheet' \
+                '    open    Open datasheet\n' \
+                '    save    Save datasheet\n' \
                 '\n' \
                 'Options:\n' \
                 '    --command <cmd>  Command to use for opening.    [default: {open_cmd}]\n' \

--- a/pyparts/parts.py
+++ b/pyparts/parts.py
@@ -448,7 +448,7 @@ class CLI:
     show =      'Usage: pyparts show [options] <part>\n' \
                 '\n' \
                 'Options:\n' \
-                '--print          Do not open, just printout URL.\n' \
+                '    --print          Do not open, just printout URL.\n' \
                 '\n'
     version =   'Pyparts v{version}: command line tool to search for parts\n' \
                 '\n' \


### PR DESCRIPTION
Here are some fixes I made for the CLI help strings:

* “show --print” only seemed to work if the option was indented
* “open” command seems to be called “show” in practice
* “datasheet” actions were laid out on the same line
* “specs” help had a space at the start

I also fixed the spelling in a doc string.
